### PR TITLE
add multi fonts in one textlayer support

### DIFF
--- a/FontFinder.sketchplugin/Contents/Sketch/findFontName.sketchscript
+++ b/FontFinder.sketchplugin/Contents/Sketch/findFontName.sketchscript
@@ -7,6 +7,8 @@ var onRun = function (context) {
     var selectingFontName = [];
     var userInterface;
     var SELECT, READY_TO_SEARCH, CANCELLED, NOT_READY;
+    //global var obj to help remove duplicated font names
+    var fontCheck={};
 
 
     initialise(context);
@@ -175,24 +177,26 @@ var onRun = function (context) {
 
 
     function showFontName(layer) {
-        var isExistFont = false;
-
-        for (var i = 0; i < includedFontName.length; i++) {
-            if (includedFontName[i] == layer.fontPostscriptName()) {
-                isExistFont = true;
+        //Command "layer.attributedString().fontNames()"  shows all fonts used in one textlayer, in a specific format
+        //I replace the '{(', ')}', '"'(\u0022), and line feeds to '' and split them in to string groups by ','
+        //and then use fontcheck{} to help remove duplicated font names
+        //P.S. 
+        //The "layer.attributedString().unavailableFontNames()" shows the missed font names in one textlayer
+        var tempFontName = layer.attributedString().fontNames().toString().replace('{(','').replace(')}','').replace(/\n/g,'').replace(/\u0022/g,'').split(',');
+        for(var z=0;z<tempFontName.length;z++){
+            var fontName = tempFontName[z];                 
+            if (!fontCheck[fontName]){
+                 fontCheck[fontName] = true;
+                 includedFontName.push(fontName);
             }
-        }
-
-        if (!isExistFont) {
-            includedFontName.push(layer.fontPostscriptName());
         }
     }
 
 
     function selectTextLayer(layer) {
-
+        //Some font names contents '"', I use '.replace(/\s+/g,"")' to clean up blanks in the store font names to get accurate search results
         for (var i = 0; i < selectingFontName.length; i++) {
-            if (layer.fontPostscriptName().match(selectingFontName[i])) {
+            if (layer.attributedString().fontNames().toString().indexOf(selectingFontName[i].replace(/\s+/g,"")) != -1) {
                 layer.select_byExpandingSelection(true, true);
             }
         }


### PR DESCRIPTION
If more then one fonts in one textlayer, the older version would show only the first one.
I think that's a limitation of "fontPostName()" method.
So I change the way of getting font names, which is the "layer.attributedString().fontNames()" method, to fixed the multi font problem.(tested in sketch 4.0)
