### PR TITLE
check null value

### DIFF
--- a/FontFinder.sketchplugin/Contents/Sketch/findFontName.cocoascript
+++ b/FontFinder.sketchplugin/Contents/Sketch/findFontName.cocoascript
@@ -189,6 +189,9 @@ var onRun = function (context) {
         //and then use fontcheck{} to help remove duplicated font names
         //P.S. 
         //The "layer.attributedString().unavailableFontNames()" shows the missed font names in one textlayer
+        if (!layer.attributedString()) {
+            return;
+        }
         var tempFontName = layer.attributedString().fontNames().toString().replace('{(','').replace(')}','').replace(/\n/g,'').replace(/\u0022/g,'').split(',');
         for(var z=0;z<tempFontName.length;z++){
             var fontName = tempFontName[z];                 
@@ -202,6 +205,9 @@ var onRun = function (context) {
 
     function selectTextLayer(layer) {
         //Some font names contents '"', I use '.replace(/\s+/g,"")' to clean up blanks in the store font names to get accurate search results
+        if (!layer.attributedString()) {
+            return;
+        }
         for (var i = 0; i < selectingFontName.length; i++) {
             if (layer.attributedString().fontNames().toString().indexOf(selectingFontName[i].replace(/\s+/g,"")) != -1) {
                 layer.select_byExpandingSelection(true, true);


### PR DESCRIPTION
When I use sketch 49, I met a weird bug in my sketch project file.  One text layer's size became 0.1. 
I don't know how to reproduce this bug. If run this plugin in this sketch file, the invalid textlayer 's `attributedString()` will be null. So I add a check null in the script. 

P.S. The following is the invalid text layer 's json description in sketch file:
```
{
			"_class": "text",
			"do_objectID": "D3B4061D-A672-4CB8-BDF9-FB75E3FB741F",
			"exportOptions": {
				"_class": "exportOptions",
				"do_objectID": "08D344E1-94F4-4E9B-8ADB-C17D811C1C63",
				"exportFormats": [],
				"includedLayerIds": [],
				"layerOptions": 0,
				"shouldTrim": false
			},
			"frame": {
				"_class": "rect",
				"do_objectID": "080FB4E1-DA0A-4D8E-AD36-D59E003733FE",
				"constrainProportions": false,
				"height": 0.1,
				"width": 0.1,
				"x": 0,
				"y": 0
			},
			"isFlippedHorizontal": false,
			"isFlippedVertical": false,
			"isLocked": false,
			"isVisible": true,
			"layerListExpandedType": 0,
			"name": "content_copy - material",
			"nameIsFixed": false,
			"resizingConstraint": 47,
			"resizingType": 0,
			"rotation": 0,
			"shouldBreakMaskChain": false,
			"style": {
				"_class": "style",
				"do_objectID": "8CAB8846-A72B-4398-9FDD-E73A05BF3B0E",
				"endDecorationType": 0,
				"miterLimit": 10,
				"startDecorationType": 0
			},
			"automaticallyDrawOnUnderlyingPath": false,
			"dontSynchroniseWithSymbol": false,
			"glyphBounds": "{{0, 0}, {0, 0}}",
			"lineSpacingBehaviour": 2,
			"textBehaviour": 0
		}
```